### PR TITLE
Ability to detect MPEG when prefixed with some noise

### DIFF
--- a/core.js
+++ b/core.js
@@ -53,6 +53,11 @@ export async function fileTypeFromTokenizer(tokenizer) {
 
 export class FileTypeParser {
 	constructor(options) {
+		this.options = {
+			mpegOffsetTollerance: 4,
+			...options,
+		};
+
 		this.detectors = options?.customDetectors;
 
 		this.fromTokenizer = this.fromTokenizer.bind(this);
@@ -1547,46 +1552,12 @@ export class FileTypeParser {
 		}
 
 		// Check MPEG 1 or 2 Layer 3 header, or 'layer 0' for ADTS (MPEG sync-word 0xFFE)
-		if (this.buffer.length >= 2 && this.check([0xFF, 0xE0], {offset: 0, mask: [0xFF, 0xE0]})) {
-			if (this.check([0x10], {offset: 1, mask: [0x16]})) {
-				// Check for (ADTS) MPEG-2
-				if (this.check([0x08], {offset: 1, mask: [0x08]})) {
-					return {
-						ext: 'aac',
-						mime: 'audio/aac',
-					};
+		if (this.buffer.length >= (2 + this.options.mpegOffsetTollerance)) {
+			for (let depth = 0; depth < this.options.mpegOffsetTollerance; ++depth) {
+				const type = this.scanMpeg(depth);
+				if (type) {
+					return type;
 				}
-
-				// Must be (ADTS) MPEG-4
-				return {
-					ext: 'aac',
-					mime: 'audio/aac',
-				};
-			}
-
-			// MPEG 1 or 2 Layer 3 header
-			// Check for MPEG layer 3
-			if (this.check([0x02], {offset: 1, mask: [0x06]})) {
-				return {
-					ext: 'mp3',
-					mime: 'audio/mpeg',
-				};
-			}
-
-			// Check for MPEG layer 2
-			if (this.check([0x04], {offset: 1, mask: [0x06]})) {
-				return {
-					ext: 'mp2',
-					mime: 'audio/mpeg',
-				};
-			}
-
-			// Check for MPEG layer 1
-			if (this.check([0x06], {offset: 1, mask: [0x06]})) {
-				return {
-					ext: 'mp1',
-					mime: 'audio/mpeg',
-				};
 			}
 		}
 	}
@@ -1654,6 +1625,56 @@ export class FileTypeParser {
 				ext: 'tif',
 				mime: 'image/tiff',
 			};
+		}
+	}
+
+	/**
+	 Scan Check MPEG 1 or 2 Layer 3 header, or 'layer 0' for ADTS (MPEG sync-word 0xFFE)
+	 @param offset to scan for sync-preamble
+	 @returns {{ext: string, mime: string}}
+	 */
+	scanMpeg(offset) {
+		if (this.check([0xFF, 0xE0], {offset, mask: [0xFF, 0xE0]})) {
+			if (this.check([0x10], {offset: offset + 1, mask: [0x16]})) {
+				// Check for (ADTS) MPEG-2
+				if (this.check([0x08], {offset: offset + 1, mask: [0x08]})) {
+					return {
+						ext: 'aac',
+						mime: 'audio/aac',
+					};
+				}
+
+				// Must be (ADTS) MPEG-4
+				return {
+					ext: 'aac',
+					mime: 'audio/aac',
+				};
+			}
+
+			// MPEG 1 or 2 Layer 3 header
+			// Check for MPEG layer 3
+			if (this.check([0x02], {offset: offset + 1, mask: [0x06]})) {
+				return {
+					ext: 'mp3',
+					mime: 'audio/mpeg',
+				};
+			}
+
+			// Check for MPEG layer 2
+			if (this.check([0x04], {offset: offset + 1, mask: [0x06]})) {
+				return {
+					ext: 'mp2',
+					mime: 'audio/mpeg',
+				};
+			}
+
+			// Check for MPEG layer 1
+			if (this.check([0x06], {offset: offset + 1, mask: [0x06]})) {
+				return {
+					ext: 'mp1',
+					mime: 'audio/mpeg',
+				};
+			}
 		}
 	}
 }


### PR DESCRIPTION
If you're adding support for a new file type, please follow the below steps:

- **One PR per file type.**
- Add a fixture file named `fixture.<extension>` to the `fixture` directory.
- Add the file extension to the `extensions` array in `supported.js`.
- Add the file's MIME type to the `types` array in `supported.js`.
- Add the file type detection logic to the `core.js` file
- Respect the sequence:
	- Signature with shorter sample size (counted from offset 0 until the last required byte position) will be executed first.
	- Only the initial determination for the file type counts for the sequence.
	- Existing signatures requiring same sample length (same *signature group*) will be tested prior to your new detections. Yours will be last. (rational: common formats first).
- Add the file extension to the `FileType` type in `core.d.ts`.
- Add the file's MIME type to the `MimeType` type in `core.d.ts`.
- Add the file extension to the `Supported file types` section of the readme in alphabetical order, in the format ```- [`<extension>`](URL) - Format name```, for example, ```- [`png`](https://en.wikipedia.org/wiki/Portable_Network_Graphics) - Portable Network Graphics```
- Add the file extension to the `keywords` array in the `package.json` file.
- Run `$ npm test` to ensure the tests pass.
- Open a pull request with a title like `Add support for Format`, for example, `Add support for PNG`.
- The pull request description should include a link to the official page of the file format or some other source. Also include a link to where you found the file type detection / magic bytes and the MIME type.
